### PR TITLE
Add Docker Image Action

### DIFF
--- a/.github/workflows/Docker-Image.yml.yml
+++ b/.github/workflows/Docker-Image.yml.yml
@@ -1,0 +1,41 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - master
+    paths:
+      - Dockerfile
+      - entrypoint.sh
+      - haproxy/**
+
+jobs:
+  BuildEggHAProxy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking Repostiory
+        uses: actions/checkout@v3
+
+      - name: Setup multiarch
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v2.0.0
+
+      - name: Login ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Build & Push EggHAProxy Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/numa-lab/docker-haproxy:latest


### PR DESCRIPTION
This pull request will add a github action to this repo, which will automatically build itself when a new commit has been pushed. Also, I'm using a tool named multiarch for the building process, for the ability to work on both x86 and arm platforms.

You will need to add ``REGISTERY_TOKEN`` to your repo secrets to get the action to work.

And just a little bit more advices, it will be better if you can link your using packages to your repo, by adding this line to your Dockerfile: ``LABEL org.opencontainers.image.source https://github.com/Numa-Lab/EggHAProxy``, or you can choose to adjust the related settings of your package. After this, you should see an extra section appear on your repo page. I did not add this change to this pull request, it's up to you.  